### PR TITLE
chore: added gitleaks as a pre-commit step

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+# Lefthook is used for configuring git hooks such as pre-commit, pre-push, etc.
+# Can read more here: https://github.com/evilmartians/lefthook
+pre-commit:
+  commands:
+    gitleaks:
+      run: gitleaks protect --verbose --redact --staged


### PR DESCRIPTION
## Why

Hello, we on Security Tools have set up a new tool to help prevent credentials getting committed into our Git repositories. There have been quite a few incidents of credentials being pushed in the clear into WS repos, and we are working to help prevent this inadvertent disclosure.

We're looking to help prevent this by leveraging a pre-commit scanning operation that utilizes [Gitleaks](https://github.com/gitleaks/gitleaks) with some customizations on top of it.

We've worked with some folks on Developer Tools to figure out the best way to manage this tool, and we have a CLI that can be installed here: https://github.com/wealthsimple/cli#installation. Doing so will install the necessary dependencies through homebrew, and setup our own Gitleaks configuration on your system.

For more information on setting up and using this tool, we have more documentation found here: https://www.notion.so/wealthsimple/Gitleaks-42fc7f2134404a56ab53fb3c1140843b. Including a link to the project brief.

## What Changed

To manage the installation of Git Hooks, we're using a tool called Lefthook: https://github.com/evilmartians/lefthook. Lefthook is a platform agnostic solution for this, and allows things like parallelization. The changes in this PR include adding a yaml file to configure Lefthook to run Gitleaks for us.

Lefthook is also installed on your system through homebrew when you follow the installation steps for `ws-cli`. Installing `ws-cli` will provide you with a zsh/bash chdir hook so that when a Lefthook file is found, `lefthook install` will be run automatically for you.

## Troubleshooting

If you run into any challenges with this new tooling or have any feedback, please reach out to us in [#proj-credentials-scanning-prevention](https://wealthsimple.slack.com/archives/C04LR3HVAA3) on Slack.
