### PR TITLE
ci: use variable for default runs-on value [skip deploy]

### DIFF
--- a/.github/workflows/detection_review.yml
+++ b/.github/workflows/detection_review.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   detection_review:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     outputs:
       reveiwlist: ${{ steps.python_output.outputs.result }}
     steps:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stats:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     steps:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master


### PR DESCRIPTION
### Why

The `ubuntu-latest` label is is moving to Ubuntu 24 starting Dec 5th, 2024.

We are changing repositories to use an org-wide variable currently set to `ubuntu-22.04`.

- Ubuntu 22 is an LTS release and should remain supported until 2027.
- Using an org-wide actions variable makes it easier to mass-migrate repos in the future, while still making it relatively easy to customize per-repo, if necessary, using a repostory-level variable to override the org-wide one.

### What Changed

- Replace usage of `ubuntu-latest` / `ubuntu-22.04` with `${{ vars.DEFAULT_RUNS_ON }}` in workflow files
